### PR TITLE
Adding support for Python2.6

### DIFF
--- a/backoff.py
+++ b/backoff.py
@@ -97,11 +97,20 @@ import operator
 import logging
 import random
 import time
+import sys
 
 
 # Use module-specific logger with a default null handler.
 logger = logging.getLogger(__name__)
-logger.addHandler(logging.NullHandler())
+
+if sys.version_info < (2, 7, 0):
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
+    logger.addHandler(NullHandler())
+else:
+    logger.addHandler(logging.NullHandler())
+
 logger.setLevel(logging.ERROR)
 
 


### PR DESCRIPTION
NullHandler was introduced in logging module in Python 2.7
This implements a NullHandler for versions below 2.7 as documented in the official Python documentation https://docs.python.org/2.6/library/logging.html#configuring-logging-for-a-library
