### PR TITLE
Use documented logger name

### DIFF
--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -6,7 +6,7 @@ import traceback
 
 
 # Use module-specific logger with a default null handler.
-logger = logging.getLogger(__name__)
+logger = logging.getLogger('backoff')
 
 if sys.version_info < (2, 7, 0):  # pragma: no cover
     class NullHandler(logging.Handler):


### PR DESCRIPTION
Commit 05b918f ("Refactor into submodules", 2017-01-23) moved the logger
declaration from __init__ to _common. As a result, the logger name is no
longer backoff but backoff._common. This commit set its back to
backoff as documented.

I believe this change should come with tests, but I did not provide any. Sorry.