### PR TITLE
Always log backoffs as INFO

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -292,9 +292,8 @@ as:
     logging.getLogger('backoff').addHandler(logging.StreamHandler())
 
 The default logging level is ERROR, which corresponds to logging anytime
-``max_tries`` is exceeded as well as any time a retryable exception is
-raised. If you would instead like to log any type of retry, you can
-set the logger level to INFO:
+``max_tries`` is exceeded. If you would instead like to log retries too,
+you can set the logger level to INFO:
 
 .. code-block:: python
 

--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -68,10 +68,9 @@ def _log_backoff(details):
     if exc is not None:
         exc_fmt = traceback.format_exception_only(exc_typ, exc)[-1]
         msg = "{0} ({1})".format(msg, exc_fmt.rstrip("\n"))
-        logger.error(msg)
     else:
         msg = "{0} ({1})".format(msg, details['value'])
-        logger.info(msg)
+    logger.info(msg)
 
 
 # Default giveup handler


### PR DESCRIPTION
But leave giving up as ERROR. This is what is documented.

This can be seen as reverting commit 49dc87c ("Log on_predicate backoffs as INFO", 2015-02-12), so maybe I'm missing something? But I would like to stop seeing backoff retries as ERROR.