### PR TITLE
Add max_time keyword argument

### DIFF
--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -6,7 +6,7 @@ import asyncio
 
 from backoff._common import (_handlers, _init_wait_gen,
                              _log_backoff, _log_giveup, _maybe_call,
-                             _next_wait)
+                             _next_wait, _total_seconds)
 
 
 def _ensure_coroutine(coro_or_func):
@@ -61,7 +61,7 @@ def retry_predicate(target, wait_gen, predicate,
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = (datetime.datetime.now() - start).total_seconds()
+            elapsed = _total_seconds(datetime.datetime.now() - start)
             details = (target, args, kwargs, tries, elapsed)
 
             ret = yield from target(*args, **kwargs)
@@ -125,7 +125,7 @@ def retry_exception(target, wait_gen, exception,
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = (datetime.datetime.now() - start).total_seconds()
+            elapsed = _total_seconds(datetime.datetime.now() - start)
             details = (target, args, kwargs, tries, elapsed)
 
             try:

--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -1,4 +1,5 @@
 # coding:utf-8
+import datetime
 import functools
 # Python 3.4 code and syntax is allowed in this module!
 import asyncio
@@ -20,12 +21,13 @@ def _ensure_coroutines(coros_or_funcs):
 
 
 @asyncio.coroutine
-def _call_handlers(hdlrs, target, args, kwargs, tries, **extra):
+def _call_handlers(hdlrs, target, args, kwargs, tries, elapsed, **extra):
     details = {
         'target': target,
         'args': args,
         'kwargs': kwargs,
         'tries': tries,
+        'elapsed': elapsed,
     }
     details.update(extra)
     for hdlr in hdlrs:
@@ -33,7 +35,7 @@ def _call_handlers(hdlrs, target, args, kwargs, tries, **extra):
 
 
 def retry_predicate(target, wait_gen, predicate,
-                    max_tries, jitter,
+                    max_tries, max_time, jitter,
                     on_success, on_backoff, on_giveup,
                     wait_gen_kwargs):
     success_hdlrs = _ensure_coroutines(_handlers(on_success))
@@ -52,21 +54,28 @@ def retry_predicate(target, wait_gen, predicate,
 
         # change names because python 2.x doesn't have nonlocal
         max_tries_ = _maybe_call(max_tries)
+        max_time_ = _maybe_call(max_time)
 
         tries = 0
+        start = datetime.datetime.now()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            details = (target, args, kwargs, tries)
+            elapsed = (datetime.datetime.now() - start).total_seconds()
+            details = (target, args, kwargs, tries, elapsed)
 
             ret = yield from target(*args, **kwargs)
             if predicate(ret):
-                if tries == max_tries_:
+                max_tries_exceeded = (tries == max_tries_)
+                max_time_exceeded = (max_time_ is not None and
+                                     elapsed >= max_time_)
+
+                if max_tries_exceeded or max_time_exceeded:
                     yield from _call_handlers(
                         giveup_hdlrs, *details, value=ret)
                     break
 
-                seconds = _next_wait(wait, jitter)
+                seconds = _next_wait(wait, jitter, elapsed, max_time_)
 
                 yield from _call_handlers(
                     backoff_hdlrs, *details, value=ret, wait=seconds)
@@ -92,7 +101,7 @@ def retry_predicate(target, wait_gen, predicate,
 
 
 def retry_exception(target, wait_gen, exception,
-                    max_tries, jitter, giveup,
+                    max_tries, max_time, jitter, giveup,
                     on_success, on_backoff, on_giveup,
                     wait_gen_kwargs):
     success_hdlrs = _ensure_coroutines(_handlers(on_success))
@@ -109,22 +118,29 @@ def retry_exception(target, wait_gen, exception,
     def retry(*args, **kwargs):
         # change names because python 2.x doesn't have nonlocal
         max_tries_ = _maybe_call(max_tries)
+        max_time_ = _maybe_call(max_time)
 
         tries = 0
+        start = datetime.datetime.now()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            details = (target, args, kwargs, tries)
+            elapsed = (datetime.datetime.now() - start).total_seconds()
+            details = (target, args, kwargs, tries, elapsed)
 
             try:
                 ret = yield from target(*args, **kwargs)
             except exception as e:
                 giveup_result = yield from giveup(e)
-                if giveup_result or tries == max_tries_:
+                max_tries_exceeded = (tries == max_tries_)
+                max_time_exceeded = (max_time_ is not None and
+                                     elapsed >= max_time_)
+
+                if giveup_result or max_tries_exceeded or max_time_exceeded:
                     yield from _call_handlers(giveup_hdlrs, *details)
                     raise
 
-                seconds = _next_wait(wait, jitter)
+                seconds = _next_wait(wait, jitter, elapsed, max_time_)
 
                 yield from _call_handlers(
                     backoff_hdlrs, *details, wait=seconds)

--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -31,7 +31,7 @@ def _init_wait_gen(wait_gen, wait_gen_kwargs):
     return wait_gen(**kwargs)
 
 
-def _next_wait(wait, jitter):
+def _next_wait(wait, jitter, elapsed, max_time):
     value = next(wait)
     try:
         if jitter is not None:
@@ -42,6 +42,10 @@ def _next_wait(wait, jitter):
         # support deprecated nullary jitter function signature
         # which returns a delta rather than a jittered value
         seconds = value + jitter()
+
+    # don't sleep longer than remaining alloted max_time
+    if max_time is not None:
+        seconds = min(seconds, max_time - elapsed)
 
     return seconds
 

--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -91,3 +91,11 @@ def _log_giveup(details):
         msg = "{0} ({1})".format(msg, details['value'])
 
     logger.error(msg)
+
+
+# Python 2.6 datetime.timedelta does not have total_seconds()
+# so we do our own implementation here.
+def _total_seconds(timedelta):
+    return (
+        (timedelta.microseconds + 0.0 +
+         (timedelta.seconds + timedelta.days * 24 * 3600) * 10**6) / 10**6)

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -11,6 +11,7 @@ from backoff import _sync
 def on_predicate(wait_gen,
                  predicate=operator.not_,
                  max_tries=None,
+                 max_time=None,
                  jitter=full_jitter,
                  on_success=None,
                  on_backoff=None,
@@ -27,8 +28,13 @@ def on_predicate(wait_gen,
             backoff on falsey return values.
         max_tries: The maximum number of attempts to make before giving
             up. In the case of failure, the result of the last attempt
-            will be returned.  The default value of None means their
-            is no limit to the number of tries.
+            will be returned. The default value of None means there
+            is no limit to the number of tries. If a callable is passed,
+            it will be evaluated at runtime and its return value used.
+        max_time: The maximum total amount of time to try for before
+            giving up. If this time expires, the result of the last
+            attempt will be returned. If a callable is passed, it will
+            be evaluated at runtime and its return value used.
         jitter: A function of the value yielded by wait_gen returning
             the actual time to wait. This distributes wait times
             stochastically in order to avoid timing collisions across
@@ -80,7 +86,7 @@ def on_predicate(wait_gen,
             retry = _sync.retry_predicate
 
         return retry(target, wait_gen, predicate,
-                     max_tries, jitter,
+                     max_tries, max_time, jitter,
                      on_success, on_backoff, on_giveup,
                      wait_gen_kwargs)
 
@@ -91,6 +97,7 @@ def on_predicate(wait_gen,
 def on_exception(wait_gen,
                  exception,
                  max_tries=None,
+                 max_time=None,
                  jitter=full_jitter,
                  giveup=lambda e: False,
                  on_success=None,
@@ -108,6 +115,10 @@ def on_exception(wait_gen,
             up. Once exhausted, the exception will be allowed to escape.
             The default value of None means their is no limit to the
             number of tries. If a callable is passed, it will be
+            evaluated at runtime and its return value used.
+        max_time: The maximum total amount of time to try for before
+            giving up. Once expired, the exception will be allowed to
+            escape. If a callable is passed, it will be
             evaluated at runtime and its return value used.
         jitter: A function of the value yielded by wait_gen returning
             the actual time to wait. This distributes wait times
@@ -162,7 +173,7 @@ def on_exception(wait_gen,
             retry = _sync.retry_exception
 
         return retry(target, wait_gen, exception,
-                     max_tries, jitter, giveup,
+                     max_tries, max_time, jitter, giveup,
                      on_success, on_backoff, on_giveup,
                      wait_gen_kwargs)
 

--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -4,7 +4,8 @@ import functools
 import time
 
 from backoff._common import (_handlers, _init_wait_gen, _log_backoff,
-                             _log_giveup, _maybe_call, _next_wait)
+                             _log_giveup, _maybe_call, _next_wait,
+                             _total_seconds)
 
 
 def _call_handlers(hdlrs, target, args, kwargs, tries, elapsed, **extra):
@@ -41,7 +42,7 @@ def retry_predicate(target, wait_gen, predicate,
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = (datetime.datetime.now() - start).total_seconds()
+            elapsed = _total_seconds(datetime.datetime.now() - start)
             details = (target, args, kwargs, tries, elapsed)
 
             ret = target(*args, **kwargs)
@@ -91,7 +92,7 @@ def retry_exception(target, wait_gen, exception,
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = (datetime.datetime.now() - start).total_seconds()
+            elapsed = _total_seconds(datetime.datetime.now() - start)
             details = (target, args, kwargs, tries, elapsed)
 
             try:

--- a/tests/python34/test_backoff_async.py
+++ b/tests/python34/test_backoff_async.py
@@ -194,6 +194,8 @@ def test_on_exception_success():
 
     for i in range(2):
         details = log['backoff'][i]
+        elapsed = details.pop('elapsed')
+        assert isinstance(elapsed, float)
         assert details == {'args': (1, 2, 3),
                            'kwargs': {'foo': 1, 'bar': 2},
                            'target': succeeder._target,
@@ -201,6 +203,8 @@ def test_on_exception_success():
                            'wait': 0}
 
     details = log['success'][0]
+    elapsed = details.pop('elapsed')
+    assert isinstance(elapsed, float)
     assert details == {'args': (1, 2, 3),
                        'kwargs': {'foo': 1, 'bar': 2},
                        'target': succeeder._target,
@@ -233,6 +237,8 @@ def test_on_exception_giveup():
     assert len(log['giveup']) == 1
 
     details = log['giveup'][0]
+    elapsed = details.pop('elapsed')
+    assert isinstance(elapsed, float)
     assert details == {'args': (1, 2, 3),
                        'kwargs': {'foo': 1, 'bar': 2},
                        'target': exceptor._target,
@@ -309,6 +315,8 @@ def test_on_predicate_success():
 
     for i in range(2):
         details = log['backoff'][i]
+        elapsed = details.pop('elapsed')
+        assert isinstance(elapsed, float)
         assert details == {'args': (1, 2, 3),
                            'kwargs': {'foo': 1, 'bar': 2},
                            'target': success._target,
@@ -317,6 +325,8 @@ def test_on_predicate_success():
                            'wait': 0}
 
     details = log['success'][0]
+    elapsed = details.pop('elapsed')
+    assert isinstance(elapsed, float)
     assert details == {'args': (1, 2, 3),
                        'kwargs': {'foo': 1, 'bar': 2},
                        'target': success._target,
@@ -348,6 +358,8 @@ def test_on_predicate_giveup():
     assert len(log['giveup']) == 1
 
     details = log['giveup'][0]
+    elapsed = details.pop('elapsed')
+    assert isinstance(elapsed, float)
     assert details == {'args': (1, 2, 3),
                        'kwargs': {'foo': 1, 'bar': 2},
                        'target': emptiness._target,
@@ -378,7 +390,9 @@ def test_on_predicate_iterable_handlers():
         assert len(hdlrs[i][0]['backoff']) == 2
         assert len(hdlrs[i][0]['giveup']) == 1
 
-        details = hdlrs[i][0]['giveup'][0]
+        details = dict(hdlrs[i][0]['giveup'][0])
+        elapsed = details.pop('elapsed')
+        assert isinstance(elapsed, float)
         assert details == {'args': (1, 2, 3),
                            'kwargs': {'foo': 1, 'bar': 2},
                            'target': emptiness._target,
@@ -418,6 +432,8 @@ def test_on_exception_success_0_arg_jitter(monkeypatch):
 
     for i in range(2):
         details = log['backoff'][i]
+        elapsed = details.pop('elapsed')
+        assert isinstance(elapsed, float)
         assert details == {'args': (1, 2, 3),
                            'kwargs': {'foo': 1, 'bar': 2},
                            'target': succeeder._target,
@@ -425,6 +441,8 @@ def test_on_exception_success_0_arg_jitter(monkeypatch):
                            'wait': 0}
 
     details = log['success'][0]
+    elapsed = details.pop('elapsed')
+    assert isinstance(elapsed, float)
     assert details == {'args': (1, 2, 3),
                        'kwargs': {'foo': 1, 'bar': 2},
                        'target': succeeder._target,
@@ -461,6 +479,8 @@ def test_on_predicate_success_0_arg_jitter(monkeypatch):
 
     for i in range(2):
         details = log['backoff'][i]
+        elapsed = details.pop('elapsed')
+        assert isinstance(elapsed, float)
         assert details == {'args': (1, 2, 3),
                            'kwargs': {'foo': 1, 'bar': 2},
                            'target': success._target,
@@ -469,6 +489,8 @@ def test_on_predicate_success_0_arg_jitter(monkeypatch):
                            'wait': 0}
 
     details = log['success'][0]
+    elapsed = details.pop('elapsed')
+    assert isinstance(elapsed, float)
     assert details == {'args': (1, 2, 3),
                        'kwargs': {'foo': 1, 'bar': 2},
                        'target': success._target,


### PR DESCRIPTION
This addresses https://github.com/litl/backoff/issues/43

The core issue is that with `full_jitter`, `max_tries` is no longer a
reliable way to control the total retry time. This adds a similar
`max_time` keyword argument which triggers a giveup after a total
elapsed amount of time rather than a set number of retries.

Further, since full_jitter is actually the default behavior, you
probably generally want to use `max_time` rather than `max_tries` so
this updates the examples in the README to show that.