### PR TITLE
Support predefined intervals wait generator

### DIFF
--- a/backoff/__init__.py
+++ b/backoff/__init__.py
@@ -14,7 +14,7 @@ https://github.com/litl/backoff
 """
 from backoff._decorator import on_predicate, on_exception
 from backoff._jitter import full_jitter, random_jitter
-from backoff._wait_gen import constant, expo, fibo
+from backoff._wait_gen import constant, expo, fibo, predefined
 
 __all__ = [
     'on_predicate',
@@ -22,6 +22,7 @@ __all__ = [
     'constant',
     'expo',
     'fibo',
+    'predefined',
     'full_jitter',
     'random_jitter'
 ]

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -48,7 +48,7 @@ def constant(interval=1):
     while True:
         yield interval
 
-        
+
 def predefined(intervals=[1]):
     """Generator for predefined intervals.
     

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -51,12 +51,11 @@ def constant(interval=1):
 
 def predefined(intervals=[1]):
     """Generator for predefined intervals.
-    
+
     Args:
         intervals: A list with the intervals to yield.
     """
     while True:
         if len(intervals):
             last = intervals.pop(0)
-        
         yield last

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -48,6 +48,7 @@ def constant(interval=1):
     while True:
         yield interval
 
+        
 def predefined(intervals=[1]):
     """Generator for predefined intervals.
     

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -47,3 +47,15 @@ def constant(interval=1):
     """
     while True:
         yield interval
+
+def predefined(intervals=[1]):
+    """Generator for predefined intervals.
+    
+    Args:
+        intervals: A list with the intervals to yield.
+    """
+    while True:
+        if len(intervals):
+            last = intervals.pop(0)
+        
+        yield last

--- a/tests/test_wait_gen.py
+++ b/tests/test_wait_gen.py
@@ -54,8 +54,7 @@ def test_constant():
 
 
 def test_predefined():
-    gen = backoff.predefined(intervals=[1,5,20])
+    gen = backoff.predefined(intervals=[1, 5, 20])
     expected = [1, 5, 20, 20, 20]
     for expect in expected:
         assert expect == next(gen)
-

--- a/tests/test_wait_gen.py
+++ b/tests/test_wait_gen.py
@@ -51,3 +51,10 @@ def test_constant():
     gen = backoff.constant(interval=3)
     for i in range(9):
         assert 3 == next(gen)
+
+def test_predefined():
+    gen = backoff.predefined(intervals=[1,5,20])
+    expected = [1, 5, 20, 20, 20]
+    for expect in expected:
+        assert expect == next(gen)
+

--- a/tests/test_wait_gen.py
+++ b/tests/test_wait_gen.py
@@ -52,6 +52,7 @@ def test_constant():
     for i in range(9):
         assert 3 == next(gen)
 
+
 def test_predefined():
     gen = backoff.predefined(intervals=[1,5,20])
     expected = [1, 5, 20, 20, 20]


### PR DESCRIPTION
This allows the user to specify custom internals via a list.

For example

```
@backoff.on_exception(backoff.predefined, Exception, max_tries=5, intervals=[1, 30, 300, 600, 1200])
def error_prone_function():
   pass
```