### PR TITLE
update pytest-asyncio to fix builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ matrix:
     dist: xenial
     sudo: true
 before_install:
-  - pip install poetry
+  - pip install poetry more-itertools
 install:
   - poetry install
 script: poetry run make check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ python = "^2.7 || ^3.4"
 flake8 = "^3.6"
 pytest = "^4.0"
 pytest-cov = "^2.6"
-pytest-asyncio = {version = "^0.9.0",python = "^3.5"}
+pytest-asyncio = {version = "^0.10.0",python = "^3.5"}
 
 [build-system]
 requires = ["poetry>=0.12"]


### PR DESCRIPTION
builds failing because of dependency issue (see below).
https://stackoverflow.com/questions/54064971/importerror-cannot-import-name-transfer-markers-when-testing-with-pytest

bump pytest-asyncio to 0.10.0