### PR TITLE
Remove python 3.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "3.7"
 matrix:
   include:
   - python: "3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,6 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Programming Language :: Python :: 2',
                'Programming Language :: Python :: 2.7',
                'Programming Language :: Python :: 3',
-               'Programming Language :: Python :: 3.4',
                'Programming Language :: Python :: 3.5',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7',
@@ -31,7 +30,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^2.7 || ^3.4"
+python = "^2.7 || ^3.5"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.6"


### PR DESCRIPTION
Python 3.4 build is broken on travis because of a poetry dep.
This version of python is end of lifed so we can just remove it.