### PR TITLE
Support python 3.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ dist/
 .cache/
 *.egg-info
 poetry.lock
+.vscode

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
 matrix:
   include:
   - python: "3.5"
@@ -12,8 +13,9 @@ matrix:
     env: PYTHONASYNCIODEBUG=x
   - python: "3.7"
     env: PYTHONASYNCIODEBUG=x
-    dist: xenial
-    sudo: true
+  - python: "3.8"
+    env: PYTHONASYNCIODEBUG=x
+
 before_install:
   - pip install poetry more-itertools
 install:

--- a/backoff/__init__.py
+++ b/backoff/__init__.py
@@ -26,4 +26,4 @@ __all__ = [
     'random_jitter'
 ]
 
-__version__ = '1.8.1'
+__version__ = '1.9.0'

--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -1,8 +1,7 @@
 # coding:utf-8
 import datetime
 import functools
-# Python 3.4 code and syntax is allowed in this module!
-import asyncio
+import asyncio  # Python 3.5 code and syntax is allowed in this file
 from datetime import timedelta
 
 from backoff._common import (_init_wait_gen, _maybe_call, _next_wait)
@@ -12,7 +11,10 @@ def _ensure_coroutine(coro_or_func):
     if asyncio.iscoroutinefunction(coro_or_func):
         return coro_or_func
     else:
-        return asyncio.coroutine(coro_or_func)
+        @functools.wraps(coro_or_func)
+        async def f(*args, **kwargs):
+            return coro_or_func(*args, **kwargs)
+        return f
 
 
 def _ensure_coroutines(coros_or_funcs):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "backoff"
-version = "1.8.1"
+version = "1.9.0"
 description = "Function decoration for backoff and retry"
 authors = ["Bob Green <rgreen@goscoutgo.com>"]
 readme = "README.rst"
@@ -20,6 +20,7 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Programming Language :: Python :: 3.5',
                'Programming Language :: Python :: 3.6',
                'Programming Language :: Python :: 3.7',
+               'Programming Language :: Python :: 3.8',
                'Topic :: Internet :: WWW/HTTP',
                'Topic :: Software Development :: Libraries :: Python Modules',
                'Topic :: Utilities']

--- a/tests/python35/test_backoff_async.py
+++ b/tests/python35/test_backoff_async.py
@@ -1,6 +1,6 @@
 # coding:utf-8
 
-import asyncio
+import asyncio  # Python 3.5 code and syntax is allowed in this file
 import backoff
 import pytest
 import random
@@ -8,9 +8,13 @@ import random
 from tests.common import _log_hdlrs, _save_target
 
 
+async def _await_none(x):
+    return None
+
+
 @pytest.mark.asyncio
 async def test_on_predicate(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     @backoff.on_predicate(backoff.expo)
     async def return_true(log, n):
@@ -26,7 +30,7 @@ async def test_on_predicate(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_predicate_max_tries(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     @backoff.on_predicate(backoff.expo, jitter=None, max_tries=3)
     async def return_true(log, n):
@@ -42,7 +46,7 @@ async def test_on_predicate_max_tries(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_exception(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     @backoff.on_exception(backoff.expo, KeyError)
     async def keyerror_then_true(log, n):
@@ -59,7 +63,7 @@ async def test_on_exception(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_exception_tuple(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     @backoff.on_exception(backoff.expo, (KeyError, ValueError))
     async def keyerror_valueerror_then_true(log):
@@ -81,7 +85,7 @@ async def test_on_exception_tuple(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_exception_max_tries(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     @backoff.on_exception(backoff.expo, KeyError, jitter=None, max_tries=3)
     async def keyerror_then_true(log, n, foo=None):
@@ -100,7 +104,7 @@ async def test_on_exception_max_tries(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_exception_constant_iterable(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     backoffs = []
     giveups = []
@@ -127,7 +131,7 @@ async def test_on_exception_constant_iterable(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_exception_success_random_jitter(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     log, log_success, log_backoff, log_giveup = _log_hdlrs()
 
@@ -158,7 +162,7 @@ async def test_on_exception_success_random_jitter(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_exception_success_full_jitter(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     log, log_success, log_backoff, log_giveup = _log_hdlrs()
 
@@ -265,7 +269,7 @@ async def test_on_exception_giveup():
 
 @pytest.mark.asyncio
 async def test_on_exception_giveup_predicate(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     def on_baz(e):
         return str(e) == "baz"
@@ -286,7 +290,7 @@ async def test_on_exception_giveup_predicate(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_exception_giveup_coro(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     async def on_baz(e):
         return str(e) == "baz"
@@ -414,7 +418,7 @@ async def test_on_predicate_iterable_handlers():
 
 @pytest.mark.asyncio
 async def test_on_predicate_constant_iterable(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     waits = [1, 2, 3, 6, 9]
     backoffs = []
@@ -446,7 +450,7 @@ async def test_on_predicate_constant_iterable(monkeypatch):
 # on_predicate should support 0-argument jitter function.
 @pytest.mark.asyncio
 async def test_on_exception_success_0_arg_jitter(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
     monkeypatch.setattr('random.random', lambda: 0)
 
     log, log_success, log_backoff, log_giveup = _log_hdlrs()
@@ -495,7 +499,7 @@ async def test_on_exception_success_0_arg_jitter(monkeypatch):
 # on_predicate should support 0-argument jitter function.
 @pytest.mark.asyncio
 async def test_on_predicate_success_0_arg_jitter(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
     monkeypatch.setattr('random.random', lambda: 0)
 
     log, log_success, log_backoff, log_giveup = _log_hdlrs()
@@ -542,7 +546,7 @@ async def test_on_predicate_success_0_arg_jitter(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_on_exception_callable_max_tries(monkeypatch):
-    monkeypatch.setattr('asyncio.sleep', asyncio.coroutine(lambda x: None))
+    monkeypatch.setattr('asyncio.sleep', _await_none)
 
     def lookup_max_tries():
         return 3


### PR DESCRIPTION
We had previously dropped support for python 3.4 but it turns out we
were still using some 3.4-isms by using the asyncio.coroutine
decorator to wrap normal functions. This replaces those instance with
the now supported (since 3.5) `async/await` syntax.

This gets rid of warnings that occcured at runtime and during unit
tests when running under python 3.8.

This address https://github.com/litl/backoff/issues/81