### PR TITLE
Make logging level for backoff and give up events configurable

### DIFF
--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -4,23 +4,15 @@ from __future__ import unicode_literals
 import logging
 import operator
 import sys
-from functools import partial
 
 from backoff._common import (
-    _prepare_logging,
+    _prepare_logger,
     _config_handlers,
     _log_backoff,
     _log_giveup
 )
 from backoff._jitter import full_jitter
 from backoff import _sync
-
-
-# python 2.7 -> 3.x compatibility for str and unicode
-try:
-    basestring
-except NameError:  # pragma: python=3.5
-    basestring = str
 
 
 def on_predicate(wait_gen,
@@ -80,16 +72,14 @@ def on_predicate(wait_gen,
     """
     def decorate(target):
         # change names because python 2.x doesn't have nonlocal
-        logger_, backoff_logging_cb, giveup_logging_cb = _prepare_logging(
-            logger, backoff_log_level, giveup_log_level
-        )
+        logger_ = _prepare_logger(logger)
 
         on_success_ = _config_handlers(on_success)
         on_backoff_ = _config_handlers(
-            on_backoff, _log_backoff, backoff_logging_cb
+            on_backoff, _log_backoff, logger_, backoff_log_level
         )
         on_giveup_ = _config_handlers(
-            on_giveup, _log_giveup, giveup_logging_cb
+            on_giveup, _log_giveup, logger_, giveup_log_level
         )
 
         retry = None
@@ -170,16 +160,14 @@ def on_exception(wait_gen,
     """
     def decorate(target):
         # change names because python 2.x doesn't have nonlocal
-        logger_, backoff_logging_cb, giveup_logging_cb = _prepare_logging(
-            logger, backoff_log_level, giveup_log_level
-        )
+        logger_ = _prepare_logger(logger)
 
         on_success_ = _config_handlers(on_success)
         on_backoff_ = _config_handlers(
-            on_backoff, _log_backoff, backoff_logging_cb
+            on_backoff, _log_backoff, logger_, backoff_log_level
         )
         on_giveup_ = _config_handlers(
-            on_giveup, _log_giveup, giveup_logging_cb
+            on_giveup, _log_giveup, logger_, giveup_log_level
         )
 
         retry = None

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -4,8 +4,14 @@ from __future__ import unicode_literals
 import logging
 import operator
 import sys
+from functools import partial
 
-from backoff._common import (_config_handlers, _log_backoff, _log_giveup)
+from backoff._common import (
+    _prepare_logging,
+    _config_handlers,
+    _log_backoff,
+    _log_giveup
+)
 from backoff._jitter import full_jitter
 from backoff import _sync
 
@@ -26,6 +32,8 @@ def on_predicate(wait_gen,
                  on_backoff=None,
                  on_giveup=None,
                  logger='backoff',
+                 backoff_log_level=logging.INFO,
+                 giveup_log_level=logging.ERROR,
                  **wait_gen_kwargs):
     """Returns decorator for backoff and retry triggered by predicate.
 
@@ -63,6 +71,8 @@ def on_predicate(wait_gen,
             about the invocation.
         logger: Name of logger or Logger object to log to. Defaults to
             'backoff'.
+        backoff_log_level: log level for the backoff event. Defaults to "INFO"
+        giveup_log_level: log level for the give up event. Defaults to "ERROR"
         **wait_gen_kwargs: Any additional keyword args specified will be
             passed to wait_gen when it is initialized.  Any callable
             args will first be evaluated and their return values passed.
@@ -70,12 +80,17 @@ def on_predicate(wait_gen,
     """
     def decorate(target):
         # change names because python 2.x doesn't have nonlocal
-        logger_ = logger
-        if isinstance(logger_, basestring):
-            logger_ = logging.getLogger(logger_)
+        logger_, backoff_logging_cb, giveup_logging_cb = _prepare_logging(
+            logger, backoff_log_level, giveup_log_level
+        )
+
         on_success_ = _config_handlers(on_success)
-        on_backoff_ = _config_handlers(on_backoff, _log_backoff, logger_)
-        on_giveup_ = _config_handlers(on_giveup, _log_giveup, logger_)
+        on_backoff_ = _config_handlers(
+            on_backoff, _log_backoff, backoff_logging_cb
+        )
+        on_giveup_ = _config_handlers(
+            on_giveup, _log_giveup, giveup_logging_cb
+        )
 
         retry = None
         if sys.version_info >= (3, 5):  # pragma: python=3.5
@@ -107,6 +122,8 @@ def on_exception(wait_gen,
                  on_backoff=None,
                  on_giveup=None,
                  logger='backoff',
+                 backoff_log_level=logging.INFO,
+                 giveup_log_level=logging.ERROR,
                  **wait_gen_kwargs):
     """Returns decorator for backoff and retry triggered by exception.
 
@@ -144,6 +161,8 @@ def on_exception(wait_gen,
             is exceeded.  The parameter is a dict containing details
             about the invocation.
         logger: Name or Logger object to log to. Defaults to 'backoff'.
+        backoff_log_level: log level for the backoff event. Defaults to "INFO"
+        giveup_log_level: log level for the give up event. Defaults to "ERROR"
         **wait_gen_kwargs: Any additional keyword args specified will be
             passed to wait_gen when it is initialized.  Any callable
             args will first be evaluated and their return values passed.
@@ -151,12 +170,17 @@ def on_exception(wait_gen,
     """
     def decorate(target):
         # change names because python 2.x doesn't have nonlocal
-        logger_ = logger
-        if isinstance(logger_, basestring):
-            logger_ = logging.getLogger(logger_)
+        logger_, backoff_logging_cb, giveup_logging_cb = _prepare_logging(
+            logger, backoff_log_level, giveup_log_level
+        )
+
         on_success_ = _config_handlers(on_success)
-        on_backoff_ = _config_handlers(on_backoff, _log_backoff, logger_)
-        on_giveup_ = _config_handlers(on_giveup, _log_giveup, logger_)
+        on_backoff_ = _config_handlers(
+            on_backoff, _log_backoff, backoff_logging_cb
+        )
+        on_giveup_ = _config_handlers(
+            on_giveup, _log_giveup, giveup_logging_cb
+        )
 
         retry = None
         if sys.version_info[:2] >= (3, 5):   # pragma: python=3.5

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,9 +1,12 @@
 # coding:utf-8
 import datetime
+import itertools
 import logging
 import random
+import re
 import sys
 import threading
+import unittest.mock
 
 import pytest
 
@@ -733,3 +736,53 @@ def test_on_exception_logger_user_str(monkeypatch, caplog):
     assert len(caplog.records) == 3  # 2 backoffs and 1 giveup
     for record in caplog.records:
         assert record.name == 'my-logger'
+
+
+@pytest.mark.parametrize(
+    ("backoff_log_level", "giveup_log_level"),
+    itertools.product(
+        (
+            logging.DEBUG,
+            logging.INFO,
+            logging.WARNING,
+            logging.ERROR,
+            logging.CRITICAL
+        ),
+        repeat=2,
+    ),
+)
+def test_on_exception_event_log_levels(
+    caplog, backoff_log_level, giveup_log_level
+):
+    max_tries = 3
+
+    @backoff.on_exception(
+        backoff.expo,
+        ValueError,
+        max_tries=max_tries,
+        backoff_log_level=backoff_log_level,
+        giveup_log_level=giveup_log_level,
+    )
+    def value_error():
+        raise ValueError
+
+    with unittest.mock.patch('time.sleep', return_value=None):
+        with caplog.at_level(
+            min(backoff_log_level, giveup_log_level), logger="backoff"
+        ):
+            with pytest.raises(ValueError):
+                value_error()
+
+    backoff_re = re.compile("backing off", re.IGNORECASE)
+    giveup_re = re.compile("giving up", re.IGNORECASE)
+
+    backoff_log_count = 0
+    giveup_log_count = 0
+    for logger_name, level, message in caplog.record_tuples:
+        if level == backoff_log_level and backoff_re.match(message):
+            backoff_log_count += 1
+        elif level == giveup_log_level and giveup_re.match(message):
+            giveup_log_count += 1
+
+    assert backoff_log_count == max_tries - 1
+    assert giveup_log_count == 1


### PR DESCRIPTION
Allow configuring log level for backoff and give up events by passing `backoff_log_level` and `giveup_log_level` parameters.