### PR TITLE
Improve performance of expo by multiplying previous result

### DIFF
--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -13,12 +13,11 @@ def expo(base=2, factor=1, max_value=None):
              true exponential sequence exceeds this, the value
              of max_value will forever after be yielded.
     """
-    n = 0
+    a = 1
     while True:
-        a = factor * base ** n
         if max_value is None or a < max_value:
-            yield a
-            n += 1
+            yield factor * a
+            a *= base
         else:
             yield max_value
 


### PR DESCRIPTION
This computes the exponential by multiplying the previous result by `base` instead of computing it from scratch with `**` each time, which seems to be about an order of magnitude faster. On my machine the following tests report around 2.63 seconds for `expo_old` and 0.10 for `expo_new`.

```python
def expo_old(base=2, factor=1, max_value=None):
    n = 0
    while True:
        a = factor * base ** n
        if max_value is None or a < max_value:
            yield a
            n += 1
        else:
            yield max_value

def expo_new(base=2, factor=1, max_value=None):
    a = 1
    while True:
        if max_value is None or a < max_value:
            yield factor * a
            a *= base
        else:
            yield max_value

import timeit

for e in (expo_old(), expo_new()):
    print(timeit.timeit('for i in range(50): next(e)', globals={'e': e}, number=1000))
```