### PR TITLE
Add typing information to external API

### DIFF
--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -32,13 +32,14 @@ else:
     Callback = Callable[[Dict[str, Any]], Any]
     GiveupCallback = Callable[[BaseException], bool]
     Exceptions = Union[Type[BaseException], Tuple[Type[BaseException], ...]]
+    JitterGen = Callable[[float], float]
 
 
 def on_predicate(wait_gen,  # type: Callable[..., Iterator[float]]
                  predicate=operator.not_,  # type: Callable[..., bool]
                  max_tries=None,  # type: Optional[int]
                  max_time=None,  # type: Optional[float]
-                 jitter=full_jitter,  # type: Callable[[float], float]
+                 jitter=full_jitter,  # type: Optional[JitterGen]
                  on_success=None,  # type: Optional[Callback]
                  on_backoff=None,  # type: Optional[Callback]
                  on_giveup=None,  # type: Optional[Callback]
@@ -120,7 +121,7 @@ def on_exception(wait_gen,  # type: Callable[..., Iterator[float]]
                  exception,  # type: Exceptions
                  max_tries=None,  # type: Optional[int]
                  max_time=None,  # type: Optional[float]
-                 jitter=full_jitter,  # type: Callable[[float], float]
+                 jitter=full_jitter,  # type: Optional[JitterGen]
                  giveup=lambda e: False,  # type: GiveupCallback
                  on_success=None,  # type: Optional[Callback]
                  on_backoff=None,  # type: Optional[Callback]

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -16,17 +16,36 @@ try:
 except NameError:  # pragma: python=3.5
     basestring = str
 
+try:
+    # This import is not used at runtime and may fail since the typing module
+    # is optional on Python v2.7. This is fine as it is only required for
+    # external static type checkers.
+    from typing import (Any, Callable, Dict, Iterator, Optional, Tuple, Type,
+                        TypeVar, Union)
+except ImportError:
+    pass
+else:
+    F = TypeVar('F', bound=Callable[..., Any])
+    # The following are short-hands for long type annotations that do not fit
+    # inside the Python 2.7-compatible type comments without ridiculous line
+    # lengths.
+    Callback = Callable[[Dict[str, Any]], Any]
+    GiveupCallback = Callable[[BaseException], bool]
+    Exceptions = Union[Type[BaseException], Tuple[Type[BaseException], ...]]
 
-def on_predicate(wait_gen,
-                 predicate=operator.not_,
-                 max_tries=None,
-                 max_time=None,
-                 jitter=full_jitter,
-                 on_success=None,
-                 on_backoff=None,
-                 on_giveup=None,
-                 logger='backoff',
-                 **wait_gen_kwargs):
+
+def on_predicate(wait_gen,  # type: Callable[..., Iterator[float]]
+                 predicate=operator.not_,  # type: Callable[..., bool]
+                 max_tries=None,  # type: Optional[int]
+                 max_time=None,  # type: Optional[float]
+                 jitter=full_jitter,  # type: Callable[[float], float]
+                 on_success=None,  # type: Optional[Callback]
+                 on_backoff=None,  # type: Optional[Callback]
+                 on_giveup=None,  # type: Optional[Callback]
+                 logger='backoff',  # type: Optional[str]
+                 **wait_gen_kwargs  # type: Dict[str, Any]
+                 ):
+    # type: (...) -> Callable[[F], F]
     """Returns decorator for backoff and retry triggered by predicate.
 
     Args:
@@ -97,17 +116,19 @@ def on_predicate(wait_gen,
     return decorate
 
 
-def on_exception(wait_gen,
-                 exception,
-                 max_tries=None,
-                 max_time=None,
-                 jitter=full_jitter,
-                 giveup=lambda e: False,
-                 on_success=None,
-                 on_backoff=None,
-                 on_giveup=None,
-                 logger='backoff',
-                 **wait_gen_kwargs):
+def on_exception(wait_gen,  # type: Callable[..., Iterator[float]]
+                 exception,  # type: Exceptions
+                 max_tries=None,  # type: Optional[int]
+                 max_time=None,  # type: Optional[float]
+                 jitter=full_jitter,  # type: Callable[[float], float]
+                 giveup=lambda e: False,  # type: GiveupCallback
+                 on_success=None,  # type: Optional[Callback]
+                 on_backoff=None,  # type: Optional[Callback]
+                 on_giveup=None,  # type: Optional[Callback]
+                 logger='backoff',  # type: Optional[str]
+                 **wait_gen_kwargs  # type: Dict[str, Any]
+                 ):
+    # type: (...) -> Callable[[F], F]
     """Returns decorator for backoff and retry triggered by exception.
 
     Args:

--- a/backoff/_jitter.py
+++ b/backoff/_jitter.py
@@ -4,6 +4,7 @@ import random
 
 
 def random_jitter(value):
+    # type: (float) -> float
     """Jitter the value a random number of milliseconds.
 
     This adds up to 1 second of additional time to the original value.
@@ -16,6 +17,7 @@ def random_jitter(value):
 
 
 def full_jitter(value):
+    # type: (float) -> float
     """Jitter the value across the full range (0 to value).
 
     This corresponds to the "Full Jitter" algorithm specified in the

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -2,8 +2,17 @@
 
 import itertools
 
+try:
+    from typing import Iterable, Iterator, Optional, Union
+except ImportError:
+    # This import is not used at runtime and may fail since the typing module
+    # is optional on Python v2.7. This is fine as it is only required for
+    # external static type checkers.
+    pass
+
 
 def expo(base=2, factor=1, max_value=None):
+    # type: (int, float, Optional[float]) -> Iterator[float]
     """Generator for exponential decay.
 
     Args:
@@ -24,6 +33,7 @@ def expo(base=2, factor=1, max_value=None):
 
 
 def fibo(max_value=None):
+    # type: (Optional[int]) -> Iterator[int]
     """Generator for fibonaccial decay.
 
     Args:
@@ -42,6 +52,7 @@ def fibo(max_value=None):
 
 
 def constant(interval=1):
+    # type: (Union[float, Iterable[float]]) -> Iterator[float]
     """Generator for constant intervals.
 
     Args:


### PR DESCRIPTION
As mentioned in #104, I have had a typed version locally for a while to satisfy my own linters. However my version was using the Python 3.5 type annotation syntax and utilities, which would break the Python 2.7 compatibility of the package. So, I converted them to the Python 2 type comment syntax for this PR.

Not exactly thrilled about those `try`-block guarded imports, but it is the only way to properly type Python 2 compatible code. Python 2.7 may be end-of-life, but this does not feel worth breaking compatibility over.

I also only covered the external API, i.e. any methods that are included in `__init__.py`'s `__all__` list. None of the runtime code has been touched, but I also have not validated this draft on versions other than Python 3.8.5 yet.