### PR TITLE
docs: fix simple typo, alloted -> allotted

### DIFF
--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -41,7 +41,7 @@ def _next_wait(wait, jitter, elapsed, max_time):
 
         seconds = value + jitter()
 
-    # don't sleep longer than remaining alloted max_time
+    # don't sleep longer than remaining allotted max_time
     if max_time is not None:
         seconds = min(seconds, max_time - elapsed)
 


### PR DESCRIPTION
There is a small typo in backoff/_common.py.

Should read `allotted` rather than `alloted`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md