### PR TITLE
Fix README typo: afters -> after

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -229,7 +229,7 @@ implemented like so:
 .. code-block:: python
 
     def backoff_hdlr(details):
-        print ("Backing off {wait:0.1f} seconds afters {tries} tries "
+        print ("Backing off {wait:0.1f} seconds after {tries} tries "
                "calling function {target} with args {args} and kwargs "
                "{kwargs}".format(**details))
 


### PR DESCRIPTION
Not much else to say. :)