### PR TITLE
update readme aiohttp example to set raise_for_status=True

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -280,7 +280,7 @@ asynchronous HTTP client/server library.
 
     @backoff.on_exception(backoff.expo, aiohttp.ClientError, max_time=60)
     async def get_url(url):
-        async with aiohttp.ClientSession() as session:
+        async with aiohttp.ClientSession(raise_for_status=True) as session:
             async with session.get(url) as response:
                 return await response.text()
 


### PR DESCRIPTION
### Background

- aiohttp's `ClientSession` interface for making requests [defaults the property](https://docs.aiohttp.org/en/stable/client_reference.html) `raise_for_status` to `False`.
- So response errors (non-200 status) don't automatically raise exceptions and therefore won't trigger `@backoff.on_exception` decorator for the async/aiohttp example code in the README.

### Changes
- Update README aiohttp example code to set  `raise_for_status=True`.