### PR TITLE
Add return-value based backoff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ flake8 = "^3.6"
 pytest = "^4.0"
 pytest-cov = "^2.6"
 pytest-asyncio = {version = "^0.10.0",python = "^3.5"}
+"backports.functools-lru-cache" = "1.6.1" # hotfix until next poetry version is released https://github.com/python-poetry/poetry/issues/3862#issuecomment-812490791
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
hopefully closes #102 

Putting this up for feedback. Happy to write tests/docs/etc.. after getting validation for the approach!

The basic idea is to add a new decorator, `on_retry_value` which takes a callable (rather than a generator). The callable takes as input the return value of the decorated method. The return value of the callable is the duration of the wait. All other params (max_wait, on_giveup, etc..) work as expected.

This allows us to handle situations where backoff depends on the return value of the method e.g: if a `requests.Response` object contains a `retry-after` type of header. 

A point to highlight: This solution uses a callable rather than a generator function. This is a departure from the current patterns. However, it felt like a generator doesn't quite fit the mold here as we need to pass the return value every time we call the decorated method. 

-------
How do we achieve this now, you might ask? 

[We engage in forbidden necromancy and bloodmagic](https://github.com/airbytehq/airbyte/blob/master/airbyte-integrations/connectors/source-freshdesk/source_freshdesk/utils.py#L55) whereby we use the `on_exception` decorator with `constant` generator with value 0, then raise an exception (essentially) containing the length of time we should wait. Then in the `on_backoff` handler we read the value from the exception and `sleep`. theremustbeabetterway.gif