### PR TITLE
README: fix typo in requests.exceptions

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,7 +312,7 @@ looked up by name.
 .. code-block:: python
 
    @backoff.on_exception(backoff.expo,
-                         requests.exception.RequestException,
+                         requests.exceptions.RequestException,
 			 logger='my_logger')
    # ...
 
@@ -327,8 +327,8 @@ directly.
     my_logger.setLevel(logging.ERROR)
 
     @backoff.on_exception(backoff.expo,
-                         requests.exception.RequestException,
-			 logger=my_logger)
+                          requests.exceptions.RequestException,
+			  logger=my_logger)
     # ...
 
 Default logging can be disabled all together by specifying


### PR DESCRIPTION
The README includes a couple typos referencing to a non-existent module `requests.exception`.
This commit fixes the typos.