### PR TITLE
Add return-value/exception based backoff time

### DIFF
--- a/backoff/__init__.py
+++ b/backoff/__init__.py
@@ -22,6 +22,7 @@ __all__ = [
     'constant',
     'expo',
     'fibo',
+    'from_value',
     'full_jitter',
     'random_jitter'
 ]

--- a/backoff/__init__.py
+++ b/backoff/__init__.py
@@ -14,7 +14,7 @@ https://github.com/litl/backoff
 """
 from backoff._decorator import on_predicate, on_exception
 from backoff._jitter import full_jitter, random_jitter
-from backoff._wait_gen import constant, expo, fibo
+from backoff._wait_gen import constant, expo, fibo, from_value
 
 __all__ = [
     'on_predicate',

--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -74,7 +74,7 @@ def retry_predicate(target, wait_gen, predicate,
                     break
 
                 try:
-                    seconds = _next_wait(wait, jitter, elapsed, max_time_)
+                    seconds = _next_wait(wait, ret, jitter, elapsed, max_time_)
                 except StopIteration:
                     await _call_handlers(on_giveup, *details, value=ret)
                     break
@@ -142,7 +142,7 @@ def retry_exception(target, wait_gen, exception,
                     raise
 
                 try:
-                    seconds = _next_wait(wait, jitter, elapsed, max_time_)
+                    seconds = _next_wait(wait, e, jitter, elapsed, max_time_)
                 except StopIteration:
                     await _call_handlers(on_giveup, *details)
                     raise e

--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -51,7 +51,7 @@ def retry_predicate(target, wait_gen, predicate,
                     break
 
                 try:
-                    seconds = _next_wait(wait, jitter, elapsed, max_time_)
+                    seconds = _next_wait(wait, ret, jitter, elapsed, max_time_)
                 except StopIteration:
                     _call_handlers(on_giveup, *details)
                     break
@@ -102,7 +102,7 @@ def retry_exception(target, wait_gen, exception,
                     raise
 
                 try:
-                    seconds = _next_wait(wait, jitter, elapsed, max_time_)
+                    seconds = _next_wait(wait, e, jitter, elapsed, max_time_)
                 except StopIteration:
                     _call_handlers(on_giveup, *details)
                     raise e

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -4,7 +4,8 @@ import itertools
 
 
 def from_value(parser):
-    """ Generator that is based on parsing the return value or thrown exception of the decorated method
+    """ Generator that is based on parsing the return value or thrown
+        exception of the decorated method
 
     Args:
         parser: a callable which takes as input the decorated

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -3,6 +3,19 @@
 import itertools
 
 
+def from_value(parser):
+    """ Generator that is based on parsing the return value or thrown exception of the decorated method
+
+    Args:
+        parser: a callable which takes as input the decorated
+            function's return value or thrown exception and
+            determines how long to wait
+    """
+    value = yield
+    while True:
+        value = yield parser(value)
+
+
 def expo(base=2, factor=1, max_value=None):
     """Generator for exponential decay.
 
@@ -13,6 +26,7 @@ def expo(base=2, factor=1, max_value=None):
              true exponential sequence exceeds this, the value
              of max_value will forever after be yielded.
     """
+    yield  # Advance past initial .send() call
     n = 0
     while True:
         a = factor * base ** n
@@ -31,6 +45,7 @@ def fibo(max_value=None):
              true fibonacci sequence exceeds this, the value
              of max_value will forever after be yielded.
     """
+    yield  # Advance past initial .send() call
     a = 1
     b = 1
     while True:
@@ -47,6 +62,7 @@ def constant(interval=1):
     Args:
         interval: A constant value to yield or an iterable of such values.
     """
+    yield  # Advance past initial .send() call
     try:
         itr = iter(interval)
     except TypeError:

--- a/tests/test_wait_gen.py
+++ b/tests/test_wait_gen.py
@@ -4,30 +4,35 @@ import backoff
 
 def test_expo():
     gen = backoff.expo()
+    gen.send(None)
     for i in range(9):
-        assert 2**i == next(gen)
+        assert 2 ** i == next(gen)
 
 
 def test_expo_base3():
     gen = backoff.expo(base=3)
+    gen.send(None)
     for i in range(9):
-        assert 3**i == next(gen)
+        assert 3 ** i == next(gen)
 
 
 def test_expo_factor3():
     gen = backoff.expo(factor=3)
+    gen.send(None)
     for i in range(9):
-        assert 3 * 2**i == next(gen)
+        assert 3 * 2 ** i == next(gen)
 
 
 def test_expo_base3_factor5():
     gen = backoff.expo(base=3, factor=5)
+    gen.send(None)
     for i in range(9):
-        assert 5 * 3**i == next(gen)
+        assert 5 * 3 ** i == next(gen)
 
 
 def test_expo_max_value():
-    gen = backoff.expo(max_value=2**4)
+    gen = backoff.expo(max_value=2 ** 4)
+    gen.send(None)
     expected = [1, 2, 4, 8, 16, 16, 16]
     for expect in expected:
         assert expect == next(gen)
@@ -35,6 +40,7 @@ def test_expo_max_value():
 
 def test_fibo():
     gen = backoff.fibo()
+    gen.send(None)
     expected = [1, 1, 2, 3, 5, 8, 13]
     for expect in expected:
         assert expect == next(gen)
@@ -42,6 +48,7 @@ def test_fibo():
 
 def test_fibo_max_value():
     gen = backoff.fibo(max_value=8)
+    gen.send(None)
     expected = [1, 1, 2, 3, 5, 8, 8, 8]
     for expect in expected:
         assert expect == next(gen)
@@ -49,5 +56,13 @@ def test_fibo_max_value():
 
 def test_constant():
     gen = backoff.constant(interval=3)
+    gen.send(None)
     for i in range(9):
         assert 3 == next(gen)
+
+
+def test_from_value():
+    gen = backoff.from_value(lambda x: x)
+    gen.send(None)
+    for i in range(20):
+        assert i == gen.send(i)


### PR DESCRIPTION
Closes #102 

Take 2 of #122 this time using @bgreen-litl 's awesome suggestion to use `.send`. 

The code is much cleaner and easier to use. The approach is to: 
1. Pass the thrown exception (if using `on_exception`) or return value (if using `on_predicate`) to the wait time generator
2. The generator yields a value just like before, but now it also has the option of inspecting the exception/return value

To make this easy to use I added a new generator `from_value` which takes a callable whose input is the exception or decoratee-return-value, and whose return value is length of time to wait. 

The consumer can use the new generator by doing: 

```
def is_rate_limited(response):
  return response.status == 429

def wait_time_from_response(response):
  return int(response.headers['retry-after'])

@backoff.on_predicate(backoff.from_value, predicate=is_rate_limited, parser=wait_time_from_response)
def foo():
  return make_http_request()
```

Questions: 
* I added one test in `test_wait_gen.py` for the new generator. Are there any additional test cases you'd recommend? Maybe something to verify that if the return value from the input callable is not a valid number (e.g: non-negative) that the appropriate exception is thrown? 


If this approach looks good I'll add docs and any more tests you recommend. 

