### PR TITLE
Prevent decorators from hiding the decorated function's signature

### DIFF
--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 import operator
-from typing import Any, Callable, Type
+from typing import Any, Callable, Optional, Type
 
 from backoff._common import (
     _prepare_logger,
@@ -26,12 +26,12 @@ from backoff._typing import (
 def on_predicate(wait_gen: _WaitGenerator,
                  predicate: _Predicate[Any] = operator.not_,
                  *,
-                 max_tries: _MaybeCallable[int] = None,
-                 max_time: _MaybeCallable[float] = None,
+                 max_tries: Optional[_MaybeCallable[int]] = None,
+                 max_time: Optional[_MaybeCallable[float]] = None,
                  jitter: _Jitterer = full_jitter,
-                 on_success: _Handler = None,
-                 on_backoff: _Handler = None,
-                 on_giveup: _Handler = None,
+                 on_success: Optional[_Handler] = None,
+                 on_backoff: Optional[_Handler] = None,
+                 on_giveup: Optional[_Handler] = None,
                  logger: _MaybeLogger = 'backoff',
                  backoff_log_level: int = logging.INFO,
                  giveup_log_level: int = logging.ERROR,
@@ -122,13 +122,13 @@ def on_predicate(wait_gen: _WaitGenerator,
 def on_exception(wait_gen: _WaitGenerator,
                  exception: _MaybeSequence[Type[Exception]],
                  *,
-                 max_tries: _MaybeCallable[int] = None,
-                 max_time: _MaybeCallable[float] = None,
+                 max_tries: Optional[_MaybeCallable[int]] = None,
+                 max_time: Optional[_MaybeCallable[float]] = None,
                  jitter: _Jitterer = full_jitter,
                  giveup: _Predicate[Exception] = lambda e: False,
-                 on_success: _Handler = None,
-                 on_backoff: _Handler = None,
-                 on_giveup: _Handler = None,
+                 on_success: Optional[_Handler] = None,
+                 on_backoff: Optional[_Handler] = None,
+                 on_giveup: Optional[_Handler] = None,
                  logger: _MaybeLogger = 'backoff',
                  backoff_log_level: int = logging.INFO,
                  giveup_log_level: int = logging.ERROR,

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -13,6 +13,7 @@ from backoff._common import (
 from backoff._jitter import full_jitter
 from backoff import _async, _sync
 from backoff._typing import (
+    _CallableT,
     _Handler,
     _Jitterer,
     _MaybeCallable,
@@ -35,7 +36,7 @@ def on_predicate(wait_gen: _WaitGenerator,
                  logger: _MaybeLogger = 'backoff',
                  backoff_log_level: int = logging.INFO,
                  giveup_log_level: int = logging.ERROR,
-                 **wait_gen_kwargs) -> Callable:
+                 **wait_gen_kwargs: Any) -> Callable[[_CallableT], _CallableT]:
     """Returns decorator for backoff and retry triggered by predicate.
 
     Args:
@@ -132,7 +133,7 @@ def on_exception(wait_gen: _WaitGenerator,
                  logger: _MaybeLogger = 'backoff',
                  backoff_log_level: int = logging.INFO,
                  giveup_log_level: int = logging.ERROR,
-                 **wait_gen_kwargs) -> Callable:
+                 **wait_gen_kwargs: Any) -> Callable[[_CallableT], _CallableT]:
     """Returns decorator for backoff and retry triggered by exception.
 
     Args:

--- a/backoff/_typing.py
+++ b/backoff/_typing.py
@@ -1,12 +1,12 @@
 # coding:utf-8
 import logging
-from typing import Any, Callable, Generator, Sequence, Union, TypeVar
+from typing import Any, Callable, Dict, Generator, Sequence, Union, TypeVar
 
 
 T = TypeVar("T")
 
 _CallableT = TypeVar('_CallableT', bound=Callable[..., Any])
-_Handler = Callable[[dict], None]
+_Handler = Callable[[Dict[str, Any]], None]
 _Jitterer = Callable[[float], float]
 _MaybeCallable = Union[T, Callable[[], T]]
 _MaybeLogger = Union[str, logging.Logger]

--- a/backoff/_typing.py
+++ b/backoff/_typing.py
@@ -1,10 +1,11 @@
 # coding:utf-8
 import logging
-from typing import Callable, Generator, Sequence, Union, TypeVar
+from typing import Any, Callable, Generator, Sequence, Union, TypeVar
 
 
 T = TypeVar("T")
 
+_CallableT = TypeVar('_CallableT', bound=Callable[..., Any])
 _Handler = Callable[[dict], None]
 _Jitterer = Callable[[float], float]
 _MaybeCallable = Union[T, Callable[[], T]]


### PR DESCRIPTION
The original `Callable` return type on decorators hid the call signature of the inner (argument-less) decorator, as well as the decorated function itself.
This PR uses a Callable-bound `TypeVar` instead and replicates the decorated function's signature in the decorator's return value.

![image](https://user-images.githubusercontent.com/35902139/125422214-c8a1e1d1-8cd0-485f-b4ae-f178f8e6051f.png)
*Example of the Pylance type checker still recognizing the type of a function after it was decorated.*

This avoids type checking errors such as Mypy's "Untyped decorator makes function "resilient_foo" untyped" warning.