### PR TITLE
Measure elapsed time after function call

### DIFF
--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -39,6 +39,9 @@ def retry_predicate(target, wait_gen, predicate,
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
+
+            ret = target(*args, **kwargs)
+
             elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
             details = {
                 "target": target,
@@ -47,8 +50,6 @@ def retry_predicate(target, wait_gen, predicate,
                 "tries": tries,
                 "elapsed": elapsed,
             }
-
-            ret = target(*args, **kwargs)
             if predicate(ret):
                 max_tries_exceeded = (tries == max_tries)
                 max_time_exceeded = (max_time is not None and
@@ -97,18 +98,19 @@ def retry_exception(target, wait_gen, exception,
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
             details = {
                 "target": target,
                 "args": args,
                 "kwargs": kwargs,
                 "tries": tries,
-                "elapsed": elapsed,
             }
 
             try:
                 ret = target(*args, **kwargs)
             except exception as e:
+                elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+                details["elapsed"] = elapsed
+
                 max_tries_exceeded = (tries == max_tries)
                 max_time_exceeded = (max_time is not None and
                                      elapsed >= max_time)
@@ -127,6 +129,9 @@ def retry_exception(target, wait_gen, exception,
 
                 time.sleep(seconds)
             else:
+                details["elapsed"] = timedelta.total_seconds(
+                    datetime.datetime.now() - start
+                )
                 _call_handlers(on_success, **details)
 
                 return ret


### PR DESCRIPTION
This patch fixes what I consider to be unexpected behavior:

*Steps to reproduce*
```
import time

import backoff


@backoff.on_exception(backoff.constant, RuntimeError, jitter=None, max_time=1)
def foo():
    print("Running")
    time.sleep(2)
    raise


def real_time():
    start = time.time()
    try:
        foo()
    except:
        pass
    print(time.time() - start)

real_time()
```

*Observed behavior*
```
$ poetry run python foo.py 
Running
Running
5.004697322845459
```

*Expected behavior*
When I specify the `max_time` argument, I expect the worst-case upper bound for execution time to be the specified timeout + the execution time of a single function call. Moreover, I would not expect retries to trigger if the give up condition is already fulfilled after the first function execution.

This behavior appears to be caused by collected `elapsed` for the `details` before the target function is executed. This patch should fix both of the above bugs by swapping that ordering.
