### PR TITLE
Update type annotations

### DIFF
--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -2,7 +2,7 @@
 import asyncio
 import logging
 import operator
-from typing import Any, Callable, Optional, Type
+from typing import Any, Callable, Iterable, Optional, Type, Union
 
 from backoff._common import (
     _prepare_logger,
@@ -30,9 +30,9 @@ def on_predicate(wait_gen: _WaitGenerator,
                  max_tries: Optional[_MaybeCallable[int]] = None,
                  max_time: Optional[_MaybeCallable[float]] = None,
                  jitter: _Jitterer = full_jitter,
-                 on_success: Optional[_Handler] = None,
-                 on_backoff: Optional[_Handler] = None,
-                 on_giveup: Optional[_Handler] = None,
+                 on_success: Union[_Handler, Iterable[_Handler]] = None,
+                 on_backoff: Union[_Handler, Iterable[_Handler]] = None,
+                 on_giveup: Union[_Handler, Iterable[_Handler]] = None,
                  logger: _MaybeLogger = 'backoff',
                  backoff_log_level: int = logging.INFO,
                  giveup_log_level: int = logging.ERROR,
@@ -127,9 +127,9 @@ def on_exception(wait_gen: _WaitGenerator,
                  max_time: Optional[_MaybeCallable[float]] = None,
                  jitter: _Jitterer = full_jitter,
                  giveup: _Predicate[Exception] = lambda e: False,
-                 on_success: Optional[_Handler] = None,
-                 on_backoff: Optional[_Handler] = None,
-                 on_giveup: Optional[_Handler] = None,
+                 on_success: Union[_Handler, Iterable[_Handler]] = None,
+                 on_backoff: Union[_Handler, Iterable[_Handler]] = None,
+                 on_giveup: Union[_Handler, Iterable[_Handler]] = None,
                  raise_on_giveup: bool = True,
                  logger: _MaybeLogger = 'backoff',
                  backoff_log_level: int = logging.INFO,

--- a/backoff/_typing.py
+++ b/backoff/_typing.py
@@ -37,7 +37,7 @@ _CallableT = TypeVar('_CallableT', bound=Callable[..., Any])
 _Handler = Callable[[Details], None]
 _Jitterer = Callable[[float], float]
 _MaybeCallable = Union[T, Callable[[], T]]
-_MaybeLogger = Union[str, logging.Logger]
+_MaybeLogger = Union[str, logging.Logger, None]
 _MaybeSequence = Union[T, Sequence[T]]
 _Predicate = Callable[[T], bool]
 _WaitGenerator = Callable[..., Generator[float, None, None]]


### PR DESCRIPTION
- Make _MaybeLogger type optional
- Update decorators on_success, on_backoff, on_giveup parameters (add iterable of callable)