### PR TITLE
disable jitter in polling example.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -166,9 +166,11 @@ gets a non-falsey result could be defined like like this:
 
 .. code-block:: python
 
-    @backoff.on_predicate(backoff.constant, interval=1)
+    @backoff.on_predicate(backoff.constant, jitter=None, interval=1)
     def poll_for_message(queue):
         return queue.get()
+
+The jitter is disabled in order to keep the polling frequency fixed.  
 
 Jitter
 ------


### PR DESCRIPTION
AFAIK the default jitter algorithm is the `full_jitter` making the polling interval vary between 0 and 1 sec in the given example.
If someone wants to have a fixed polling interval/frequency as the lead of this example suggests then jitter should be disabled.