### PR TITLE
Feature/monotonic

### DIFF
--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -1,8 +1,7 @@
 # coding:utf-8
-import datetime
+import time
 import functools
 import asyncio
-from datetime import timedelta
 
 from backoff._common import (_init_wait_gen, _maybe_call, _next_wait)
 
@@ -41,6 +40,7 @@ def retry_predicate(target, wait_gen, predicate,
                     *,
                     max_tries, max_time, jitter,
                     on_success, on_backoff, on_giveup,
+                    monotonic_time=None,
                     wait_gen_kwargs):
     on_success = _ensure_coroutines(on_success)
     on_backoff = _ensure_coroutines(on_backoff)
@@ -61,11 +61,11 @@ def retry_predicate(target, wait_gen, predicate,
         max_time = _maybe_call(max_time)
 
         tries = 0
-        start = datetime.datetime.now()
+        start = (monotonic_time or time.monotonic)()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            elapsed = (monotonic_time or time.monotonic)() - start
             details = {
                 "target": target,
                 "args": args,
@@ -117,6 +117,7 @@ def retry_exception(target, wait_gen, exception,
                     *,
                     max_tries, max_time, jitter, giveup,
                     on_success, on_backoff, on_giveup, raise_on_giveup,
+                    monotonic_time=None,
                     wait_gen_kwargs):
     on_success = _ensure_coroutines(on_success)
     on_backoff = _ensure_coroutines(on_backoff)
@@ -136,11 +137,11 @@ def retry_exception(target, wait_gen, exception,
         max_time = _maybe_call(max_time)
 
         tries = 0
-        start = datetime.datetime.now()
+        start = (monotonic_time or time.monotonic)()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            elapsed = (monotonic_time or time.monotonic)() - start
             details = {
                 "target": target,
                 "args": args,

--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -41,6 +41,7 @@ def retry_predicate(target, wait_gen, predicate,
                     max_tries, max_time, jitter,
                     on_success, on_backoff, on_giveup,
                     monotonic_time=None,
+                    sleep=None,
                     wait_gen_kwargs):
     on_success = _ensure_coroutines(on_success)
     on_backoff = _ensure_coroutines(on_backoff)
@@ -102,7 +103,7 @@ def retry_predicate(target, wait_gen, predicate,
                 # See for details:
                 #   <https://groups.google.com/forum/#!topic/python-tulip/yF9C-rFpiKk>
                 #   <https://bugs.python.org/issue28613>
-                await asyncio.sleep(seconds)
+                await (sleep or asyncio.sleep)(seconds)
                 continue
             else:
                 await _call_handlers(on_success, **details, value=ret)
@@ -117,6 +118,7 @@ def retry_exception(target, wait_gen, exception,
                     *,
                     max_tries, max_time, jitter, giveup,
                     on_success, on_backoff, on_giveup, raise_on_giveup,
+                    sleep=None,
                     monotonic_time=None,
                     wait_gen_kwargs):
     on_success = _ensure_coroutines(on_success)
@@ -181,7 +183,7 @@ def retry_exception(target, wait_gen, exception,
                 # See for details:
                 #   <https://groups.google.com/forum/#!topic/python-tulip/yF9C-rFpiKk>
                 #   <https://bugs.python.org/issue28613>
-                await asyncio.sleep(seconds)
+                await (sleep or asyncio.sleep)(seconds)
             else:
                 await _call_handlers(on_success, **details)
 

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -33,6 +33,8 @@ def on_predicate(wait_gen: _WaitGenerator,
                  on_success: Union[_Handler, Iterable[_Handler]] = None,
                  on_backoff: Union[_Handler, Iterable[_Handler]] = None,
                  on_giveup: Union[_Handler, Iterable[_Handler]] = None,
+                 monotonic_time: Optional[Callable[[], float]] = None,
+                 sleep: Optional[Callable[[float], None]] = None,
                  logger: _MaybeLogger = 'backoff',
                  backoff_log_level: int = logging.INFO,
                  giveup_log_level: int = logging.ERROR,
@@ -113,6 +115,8 @@ def on_predicate(wait_gen: _WaitGenerator,
             on_success=on_success,
             on_backoff=on_backoff,
             on_giveup=on_giveup,
+            monotonic_time=monotonic_time,
+            sleep=sleep,
             wait_gen_kwargs=wait_gen_kwargs
         )
 

--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -1,8 +1,6 @@
 # coding:utf-8
-import datetime
 import functools
 import time
-from datetime import timedelta
 
 from backoff._common import (_init_wait_gen, _maybe_call, _next_wait)
 
@@ -24,6 +22,7 @@ def retry_predicate(target, wait_gen, predicate,
                     *,
                     max_tries, max_time, jitter,
                     on_success, on_backoff, on_giveup,
+                    monotonic_time=None,
                     wait_gen_kwargs):
 
     @functools.wraps(target)
@@ -35,11 +34,11 @@ def retry_predicate(target, wait_gen, predicate,
         max_time = _maybe_call(max_time)
 
         tries = 0
-        start = datetime.datetime.now()
+        start = (monotonic_time or time.monotonic)()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            elapsed = (monotonic_time or time.monotonic)() - start
             details = {
                 "target": target,
                 "args": args,
@@ -82,6 +81,7 @@ def retry_exception(target, wait_gen, exception,
                     *,
                     max_tries, max_time, jitter, giveup,
                     on_success, on_backoff, on_giveup, raise_on_giveup,
+                    monotonic_time=None,
                     wait_gen_kwargs):
 
     @functools.wraps(target)
@@ -93,11 +93,11 @@ def retry_exception(target, wait_gen, exception,
         max_time = _maybe_call(max_time)
 
         tries = 0
-        start = datetime.datetime.now()
+        start = (monotonic_time or time.monotonic)()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            elapsed = (monotonic_time or time.monotonic)() - start
             details = {
                 "target": target,
                 "args": args,

--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -23,6 +23,7 @@ def retry_predicate(target, wait_gen, predicate,
                     max_tries, max_time, jitter,
                     on_success, on_backoff, on_giveup,
                     monotonic_time=None,
+                    sleep=None,
                     wait_gen_kwargs):
 
     @functools.wraps(target)
@@ -66,7 +67,7 @@ def retry_predicate(target, wait_gen, predicate,
                 _call_handlers(on_backoff, **details,
                                value=ret, wait=seconds)
 
-                time.sleep(seconds)
+                (sleep or time.sleep)(seconds)
                 continue
             else:
                 _call_handlers(on_success, **details, value=ret)
@@ -82,6 +83,7 @@ def retry_exception(target, wait_gen, exception,
                     max_tries, max_time, jitter, giveup,
                     on_success, on_backoff, on_giveup, raise_on_giveup,
                     monotonic_time=None,
+                    sleep=None,
                     wait_gen_kwargs):
 
     @functools.wraps(target)
@@ -127,7 +129,7 @@ def retry_exception(target, wait_gen, exception,
 
                 _call_handlers(on_backoff, **details, wait=seconds)
 
-                time.sleep(seconds)
+                (sleep or time.sleep)(seconds)
             else:
                 _call_handlers(on_success, **details)
 


### PR DESCRIPTION
This fixes #149  and #125.

This pull request proposes the use of `time.monotonic` by default instead of `datatime.now`. A monotonic clock has the garantee of never gong back in time, which is what we want when computing elapsed time. 