### PR TITLE
pyupgrade --py37-plus **/*.py

### DIFF
--- a/backoff/__init__.py
+++ b/backoff/__init__.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 """
 Function decoration for backoff and retry
 

--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import datetime
 import functools
 import asyncio

--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 import functools
 import logging
 import sys

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import asyncio
 import logging
 import operator

--- a/backoff/_jitter.py
+++ b/backoff/_jitter.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 import random
 
 

--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import datetime
 import functools
 import time

--- a/backoff/_typing.py
+++ b/backoff/_typing.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import logging
 import sys
 from typing import (Any, Callable, Dict, Generator, Sequence, Tuple, Union,

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 import itertools
 from typing import Any, Callable, Generator, Iterable, Optional, Union
 
@@ -68,8 +66,7 @@ def constant(
     except TypeError:
         itr = itertools.repeat(interval)  # type: ignore
 
-    for val in itr:
-        yield val
+    yield from itr
 
 
 def runtime(*, value: Callable[[Any], int]) -> Generator[int, None, None]:

--- a/backoff/types.py
+++ b/backoff/types.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 from ._typing import Details
 
 __all__ = [

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import collections
 import functools
 

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import datetime
 import itertools
 import logging

--- a/tests/test_backoff_async.py
+++ b/tests/test_backoff_async.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 import asyncio  # Python 3.5 code and syntax is allowed in this file
 import backoff
 import pytest

--- a/tests/test_jitter.py
+++ b/tests/test_jitter.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import backoff
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 from backoff.types import Details
 
 

--- a/tests/test_wait_gen.py
+++ b/tests/test_wait_gen.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import backoff
 
 


### PR DESCRIPTION
[`pyupgrade` automatically upgrades syntax for newer versions of the language.](https://github.com/asottile/pyupgrade#pyupgrade)

`#  coding:utf-8` is a [no-op in Python 3](https://github.com/asottile/pyupgrade#-coding--comment) because all Python source files are utf-8 by default.