### PR TITLE
Get max_tries/max_time values for every call fixes #160

### DIFF
--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -28,11 +28,8 @@ def retry_predicate(target, wait_gen, predicate,
 
     @functools.wraps(target)
     def retry(*args, **kwargs):
-
-        # update variables from outer function args
-        nonlocal max_tries, max_time
-        max_tries = _maybe_call(max_tries)
-        max_time = _maybe_call(max_time)
+        max_tries_value = _maybe_call(max_tries)
+        max_time_value = _maybe_call(max_time)
 
         tries = 0
         start = datetime.datetime.now()
@@ -50,9 +47,9 @@ def retry_predicate(target, wait_gen, predicate,
 
             ret = target(*args, **kwargs)
             if predicate(ret):
-                max_tries_exceeded = (tries == max_tries)
+                max_tries_exceeded = (tries == max_tries_value)
                 max_time_exceeded = (max_time is not None and
-                                     elapsed >= max_time)
+                                     elapsed >= max_time_value)
 
                 if max_tries_exceeded or max_time_exceeded:
                     _call_handlers(on_giveup, **details, value=ret)
@@ -86,11 +83,8 @@ def retry_exception(target, wait_gen, exception,
 
     @functools.wraps(target)
     def retry(*args, **kwargs):
-
-        # update variables from outer function args
-        nonlocal max_tries, max_time
-        max_tries = _maybe_call(max_tries)
-        max_time = _maybe_call(max_time)
+        max_tries_value = _maybe_call(max_tries)
+        max_time_value = _maybe_call(max_time)
 
         tries = 0
         start = datetime.datetime.now()
@@ -109,9 +103,9 @@ def retry_exception(target, wait_gen, exception,
             try:
                 ret = target(*args, **kwargs)
             except exception as e:
-                max_tries_exceeded = (tries == max_tries)
+                max_tries_exceeded = (tries == max_tries_value)
                 max_time_exceeded = (max_time is not None and
-                                     elapsed >= max_time)
+                                     elapsed >= max_time_value)
 
                 if giveup(e) or max_tries_exceeded or max_time_exceeded:
                     _call_handlers(on_giveup, **details)

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -548,6 +548,29 @@ def test_on_exception_callable_max_tries(monkeypatch):
     assert len(log) == 3
 
 
+def test_on_exception_callable_max_tries_reads_every_time(monkeypatch):
+    monkeypatch.setattr('time.sleep', lambda x: None)
+
+    lookups = []
+    def lookup_max_tries():
+        lookups.append(True)
+        return 3
+
+    @backoff.on_exception(backoff.constant,
+                          ValueError,
+                          max_tries=lookup_max_tries)
+    def exceptor():
+        raise ValueError()
+
+    with pytest.raises(ValueError):
+        exceptor()
+
+    with pytest.raises(ValueError):
+        exceptor()
+
+    assert len(lookups) == 2
+
+
 def test_on_exception_callable_gen_kwargs():
 
     def lookup_foo():

--- a/tests/test_backoff_async.py
+++ b/tests/test_backoff_async.py
@@ -572,6 +572,31 @@ async def test_on_exception_callable_max_tries(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_on_exception_callable_max_tries_reads_every_time(monkeypatch):
+    monkeypatch.setattr('asyncio.sleep', _await_none)
+
+    lookups = []
+    def lookup_max_tries():
+        lookups.append(True)
+        return 3
+
+    @backoff.on_exception(backoff.constant,
+                          ValueError,
+                          max_tries=lookup_max_tries)
+    def exceptor():
+        raise ValueError()
+
+    with pytest.raises(ValueError):
+        exceptor()
+
+    with pytest.raises(ValueError):
+        exceptor()
+
+    assert len(lookups) == 2
+
+
+
+@pytest.mark.asyncio
 async def test_on_exception_callable_gen_kwargs():
 
     def lookup_foo():


### PR DESCRIPTION
Changes backoff to dynamically get the `max_tries` and `max_time` values for every new call and always try to evaluate. 
Avoid caching the first obtained value for all executions.

See #160 