### PR TITLE
Improve type annotation for backoff.expo

### DIFF
--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -5,10 +5,10 @@ from typing import Any, Callable, Generator, Iterable, Optional, Union
 
 
 def expo(
-    base: int = 2,
-    factor: int = 1,
-    max_value: Optional[int] = None
-) -> Generator[int, Any, None]:
+    base: float = 2,
+    factor: float = 1,
+    max_value: Optional[float] = None
+) -> Generator[float, Any, None]:
 
     """Generator for exponential decay.
 


### PR DESCRIPTION
`backoff.expo` accepts floats. Most usage in our codebase has a floating point `factor`. If we want to preserve exact inference in cases where the return type is `Generator[int, Any, None` we could use an overload (TypeVar could work, but would be a little worse for cases involving defaults).