### PR TITLE
Started using `timeit` for measuring elapsed time

### DIFF
--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -2,6 +2,7 @@
 import datetime
 import functools
 import asyncio
+import timeit
 from datetime import timedelta
 
 from backoff._common import (_init_wait_gen, _maybe_call, _next_wait)
@@ -60,11 +61,11 @@ def retry_predicate(target, wait_gen, predicate,
         max_time_value = _maybe_call(max_time)
 
         tries = 0
-        start = datetime.datetime.now()
+        start = timeit.default_timer()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            elapsed = timeit.default_timer() - start
             details = {
                 "target": target,
                 "args": args,
@@ -134,11 +135,11 @@ def retry_exception(target, wait_gen, exception,
         max_time_value = _maybe_call(max_time)
 
         tries = 0
-        start = datetime.datetime.now()
+        start = timeit.default_timer()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            elapsed = timeit.default_timer() - start
             details = {
                 "target": target,
                 "args": args,

--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -2,6 +2,7 @@
 import datetime
 import functools
 import time
+import timeit
 from datetime import timedelta
 
 from backoff._common import (_init_wait_gen, _maybe_call, _next_wait)
@@ -32,11 +33,11 @@ def retry_predicate(target, wait_gen, predicate,
         max_time_value = _maybe_call(max_time)
 
         tries = 0
-        start = datetime.datetime.now()
+        start = timeit.default_timer()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            elapsed = timeit.default_timer() - start
             details = {
                 "target": target,
                 "args": args,
@@ -88,11 +89,11 @@ def retry_exception(target, wait_gen, exception,
         max_time_value = _maybe_call(max_time)
 
         tries = 0
-        start = datetime.datetime.now()
+        start = timeit.default_timer()
         wait = _init_wait_gen(wait_gen, wait_gen_kwargs)
         while True:
             tries += 1
-            elapsed = timedelta.total_seconds(datetime.datetime.now() - start)
+            elapsed = timeit.default_timer() - start
             details = {
                 "target": target,
                 "args": args,


### PR DESCRIPTION
There is some evidence based on Datadog traces that `backoff` library does not calculate elapsed time correctly. For example, there are occurrences where extra retries are made even though the elapsed time exceeds specified `max_time` parameter for `backoff.on_exception` decorator. I suspect the problem is due to system clock being adjusted for time drift, or a similar issue.

I propose to use `timeit` instead of `datetime.datetime.now()` for measuring elapsed time.