### PR TITLE
Enable use with staticmethods

### DIFF
--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -31,6 +31,13 @@ def _init_wait_gen(wait_gen, wait_gen_kwargs):
     return initialized
 
 
+def _get_func(func):
+    if isinstance(func, staticmethod):
+        return func.__func__
+    else:
+        return func
+
+
 def _next_wait(wait, send_value, jitter, elapsed, max_time):
     value = wait.send(send_value)
     try:
@@ -88,7 +95,7 @@ def _config_handlers(
         # append a single handler
         handlers.append(user_handlers)
 
-    return handlers
+    return [_get_func(h) for h in handlers]
 
 
 # Default backoff handler


### PR DESCRIPTION
This PR adds functionality to extract the underlying functions from staticmethods.

For each specified method (including the wrapped method and any on_backoff/on_giveup/on_success methods), it checks if it's a staticmethod and if so extracts the wrapped function from `target.__func__`