### PR TITLE
drop python<=3.7 support

### DIFF
--- a/backoff/__init__.py
+++ b/backoff/__init__.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 """
 Function decoration for backoff and retry
 

--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import datetime
 import functools
 import asyncio

--- a/backoff/_common.py
+++ b/backoff/_common.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 import functools
 import logging
 import sys

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import asyncio
 import logging
 import operator

--- a/backoff/_jitter.py
+++ b/backoff/_jitter.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 import random
 
 

--- a/backoff/_sync.py
+++ b/backoff/_sync.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import datetime
 import functools
 import time

--- a/backoff/_typing.py
+++ b/backoff/_typing.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from typing import (Any, Callable, Coroutine, Dict, Generator, Sequence, Tuple,
                     TypeVar, Union)
 

--- a/backoff/_typing.py
+++ b/backoff/_typing.py
@@ -1,19 +1,9 @@
-# coding:utf-8
 import logging
 import sys
 from typing import (Any, Callable, Coroutine, Dict, Generator, Sequence, Tuple,
                     TypeVar, Union)
 
-if sys.version_info >= (3, 8):  # pragma: no cover
-    from typing import TypedDict
-else:  # pragma: no cover
-    # use typing_extensions if installed but don't require it
-    try:
-        from typing_extensions import TypedDict
-    except ImportError:
-        class TypedDict(dict):
-            def __init_subclass__(cls, **kwargs: Any) -> None:
-                return super().__init_subclass__()
+from typing import TypedDict
 
 
 class _Details(TypedDict):

--- a/backoff/_wait_gen.py
+++ b/backoff/_wait_gen.py
@@ -1,8 +1,11 @@
 # coding:utf-8
 
-import itertools
 import math
 from typing import Any, Callable, Generator, Iterable, Optional, Union
+from typing import Any
+import sys
+if sys.version_info < (3,12):
+    import itertools
 
 
 def expo(
@@ -93,10 +96,10 @@ def constant(
     # Advance past initial .send() call
     yield  # type: ignore[misc]
 
-    try:
-        itr = iter(interval)  # type: ignore
-    except TypeError:
+    if sys.version_info < (3,12):
         itr = itertools.repeat(interval)  # type: ignore
+    else:
+        itr = iter(interval)  # type: ignore
 
     for val in itr:
         yield val

--- a/backoff/types.py
+++ b/backoff/types.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 from ._typing import Details
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,10 +15,11 @@ classifiers = ['Development Status :: 5 - Production/Stable',
                'Operating System :: OS Independent',
                'Programming Language :: Python',
                'Programming Language :: Python :: 3',
-               'Programming Language :: Python :: 3.7',
                'Programming Language :: Python :: 3.8',
                'Programming Language :: Python :: 3.9',
                'Programming Language :: Python :: 3.10',
+               'Programming Language :: Python :: 3.11',
+               'Programming Language :: Python :: 3.12',
                'Topic :: Internet :: WWW/HTTP',
                'Topic :: Software Development :: Libraries :: Python Modules',
                'Topic :: Utilities']
@@ -27,7 +28,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.7"
+python = ">=3.8"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^4.0.1"

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import collections
 import functools
 

--- a/tests/test_backoff.py
+++ b/tests/test_backoff.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import datetime
 import itertools
 import logging

--- a/tests/test_backoff_async.py
+++ b/tests/test_backoff_async.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 import asyncio  # Python 3.5 code and syntax is allowed in this file
 import random
 

--- a/tests/test_jitter.py
+++ b/tests/test_jitter.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import backoff
 
 

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,5 +1,3 @@
-# coding:utf-8
-
 from backoff.types import Details
 
 

--- a/tests/test_wait_gen.py
+++ b/tests/test_wait_gen.py
@@ -1,4 +1,3 @@
-# coding:utf-8
 import backoff
 import math
 


### PR DESCRIPTION
According to https://endoflife.date/python python 3.7 has been EOSed 27 Jun 2023.
Filter all code over `pyupgracde --py38-plus`.