### PR TITLE
Use `inspect.iscoroutinefunction` instead of `asyncio.iscoroutinefunction` to avoid Python 3.14 deprecation warning

### DIFF
--- a/backoff/_async.py
+++ b/backoff/_async.py
@@ -1,5 +1,6 @@
 # coding:utf-8
 import datetime
+import inspect
 import functools
 import asyncio
 from datetime import timedelta
@@ -8,7 +9,7 @@ from backoff._common import (_init_wait_gen, _maybe_call, _next_wait)
 
 
 def _ensure_coroutine(coro_or_func):
-    if asyncio.iscoroutinefunction(coro_or_func):
+    if inspect.iscoroutinefunction(coro_or_func):
         return coro_or_func
     else:
         @functools.wraps(coro_or_func)
@@ -47,10 +48,10 @@ def retry_predicate(target, wait_gen, predicate,
     on_giveup = _ensure_coroutines(on_giveup)
 
     # Easy to implement, please report if you need this.
-    assert not asyncio.iscoroutinefunction(max_tries)
-    assert not asyncio.iscoroutinefunction(jitter)
+    assert not inspect.iscoroutinefunction(max_tries)
+    assert not inspect.iscoroutinefunction(jitter)
 
-    assert asyncio.iscoroutinefunction(target)
+    assert inspect.iscoroutinefunction(target)
 
     @functools.wraps(target)
     async def retry(*args, **kwargs):
@@ -124,8 +125,8 @@ def retry_exception(target, wait_gen, exception,
     giveup = _ensure_coroutine(giveup)
 
     # Easy to implement, please report if you need this.
-    assert not asyncio.iscoroutinefunction(max_tries)
-    assert not asyncio.iscoroutinefunction(jitter)
+    assert not inspect.iscoroutinefunction(max_tries)
+    assert not inspect.iscoroutinefunction(jitter)
 
     @functools.wraps(target)
     async def retry(*args, **kwargs):

--- a/backoff/_decorator.py
+++ b/backoff/_decorator.py
@@ -1,5 +1,5 @@
 # coding:utf-8
-import asyncio
+import inspect
 import logging
 import operator
 from typing import Any, Callable, Iterable, Optional, Type, Union
@@ -98,7 +98,7 @@ def on_predicate(wait_gen: _WaitGenerator,
             log_level=giveup_log_level
         )
 
-        if asyncio.iscoroutinefunction(target):
+        if inspect.iscoroutinefunction(target):
             retry = _async.retry_predicate
         else:
             retry = _sync.retry_predicate
@@ -198,7 +198,7 @@ def on_exception(wait_gen: _WaitGenerator,
             log_level=giveup_log_level,
         )
 
-        if asyncio.iscoroutinefunction(target):
+        if inspect.iscoroutinefunction(target):
             retry = _async.retry_exception
         else:
             retry = _sync.retry_exception


### PR DESCRIPTION
The function `asyncio.iscoroutinefunction` was recently deprecated in Python 3.14.0a1 and will be removed in Python 3.16: https://docs.python.org/3.14/whatsnew/3.14.html#deprecated.

The function's had a consistent implementation at least since Python 3.7:

- https://github.com/python/cpython/blob/3.7/Lib/asyncio/coroutines.py#L160-L163
- https://github.com/python/cpython/blob/3.8/Lib/asyncio/coroutines.py#L164-L167
- https://github.com/python/cpython/blob/v3.9.20/Lib/asyncio/coroutines.py#L164-L167
- https://github.com/python/cpython/blob/v3.10.15/Lib/asyncio/coroutines.py#L164-L167
- https://github.com/python/cpython/blob/v3.11.10/Lib/asyncio/coroutines.py#L21-L24
- https://github.com/python/cpython/blob/v3.12.7/Lib/asyncio/coroutines.py#L20-L23

Which means it's safe to use `inspect.iscoroutinefunction` in this package without checking the Python version.

FWIW the deprecation first appears in:

https://github.com/python/cpython/blob/v3.14.0b1/Lib/asyncio/coroutines.py#L20-L27